### PR TITLE
Add functionality to get Temperature from string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ readme = "README.md"
 
 [features]
 no_std = []
+from_str = ["regex"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
+regex = { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ fn main() {
 }
 ```
 
+### Features
+
+The crate contains few features to disable or enable certain functionalities:
+
+* no_std
+    * Removes functionality that Rust std library provides
+* from_str
+    * Allows creating measurement units from string input
+
 --------------------------------------
 
 **References**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ use std::time as time;
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "from_str")]
+extern crate regex;
+
 use std::f64::consts::PI as PI;
 
 #[macro_use]


### PR DESCRIPTION
This functionality adds possibility to pass a string value to create new Temperature unit. If the string value ends with the symbol of the unit, it will create a Temperature from that unit, otherwise it will default to Celsius. Empty string values are considered also as 0.0 degrees Celsius. 

Additionally this same can be added to other units as well but I am first looking forward from hearing from you what do you think? We actually created builders for this in our project https://github.com/drodil/rustybeer so that user can input units easily from the command line.