### PR TITLE
Replace no_std feature with std feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        FEATURES: ['', 'from_str', 'no_std']
+        FEATURES: ['', 'from_str', 'std']
 
         include:
           # Test nightly but don't fail
@@ -62,7 +62,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.TARGET }} --features no_std
+          args: --target=${{ matrix.TARGET }}
 
   fmt:
     runs-on: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        FEATURES: ['', 'from_str', 'no_std']
+        FEATURES: ['', 'from_str', 'std']
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced the `no_std` feature with an additive `std` feature, fixing problems with serde serialization on `no_std` targets.
+
 ## [0.10.4]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [features]
 std = []
-from_str = ["regex"]
+from_str = ["regex", "std"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-no_std = [ "libm" ]
+std = []
 from_str = ["regex"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 regex = { version = "1", optional = true }
-libm = { version = "0.2", optional = true }
+libm = { version = "0.2" }

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ fn main() {
 
 The crate contains few features to disable or enable certain functionalities:
 
-* no_std
-    * Removes functionality that Rust std library provides
+* std
+    * Enables functionality that Rust std library provides instead of using libm for some maths functions
 * from_str
     * Allows creating measurement units from string input
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ fn main() {
 
 The crate contains few features to disable or enable certain functionalities:
 
-* std
-    * Enables functionality that Rust std library provides instead of using libm for some maths functions
+* `std`
+    * Enables functionality that Rust standard library provides instead of using `libm` for some math functions
 * from_str
     * Allows creating measurement units from string input
 

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -47,43 +47,43 @@ impl Angle {
     }
 
     /// Calculate the cosine of this angle
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn cos(&self) -> f64 {
         self.radians.cos()
     }
 
     /// Calculate the sine of this angle
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn sin(&self) -> f64 {
         self.radians.sin()
     }
 
     /// Calculate the sine and cosine of this angle
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn sin_cos(&self) -> (f64, f64) {
         self.radians.sin_cos()
     }
 
     /// Calculate the tangent of this angle
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tan(&self) -> f64 {
         self.radians.tan()
     }
 
     /// Calculate the arcsine of a number
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn asin(num: f64) -> Self {
         Angle::from_radians(num.asin())
     }
 
     /// Calculate the arccosine of a number
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn acos(num: f64) -> Self {
         Angle::from_radians(num.acos())
     }
 
     /// Calculate the arctangent of a number
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn atan(num: f64) -> Self {
         Angle::from_radians(num.atan())
     }

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -69,7 +69,7 @@ impl Humidity {
     /// Calculates Dewpoint from humidity and air temperature using the Magnus-Tetens
     /// approximation, with coefficients derived by Alduchov and Eskridge (1996). The formulas assume
     //  standard atmospheric pressure.
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn as_dewpoint(&self, temp: Temperature) -> Temperature {
         let humidity = self.relative_humidity / 100.0;
         let celsius = temp.as_celsius();
@@ -81,7 +81,7 @@ impl Humidity {
     /// Calculates Dewpoint from humidity and air temperature using the Magnus-Tetens
     /// approximation, with coefficients derived by Alduchov and Eskridge (1996). The formulas assume
     //  standard atmospheric pressure.
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     pub fn as_dewpoint(&self, temp: Temperature) -> Temperature {
         let humidity = self.relative_humidity / 100.0;
         let celsius = temp.as_celsius();
@@ -94,7 +94,7 @@ impl Humidity {
     /// Calculates the actual vapour pressure in the air, based on the air temperature and humidity
     /// at standard atmospheric pressure (1013.25 mb), using the Buck formula (accurate to +/- 0.02%
     /// between 0 deg C and 50 deg C)
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn as_vapor_pressure(&self, temp: Temperature) -> Pressure {
         let temp = temp.as_celsius();
         let saturation_vapor_pressure =
@@ -105,7 +105,7 @@ impl Humidity {
     /// Calculates the actual vapour pressure in the air, based on the air temperature and humidity
     /// at standard atmospheric pressure (1013.25 mb), using the Buck formula (accurate to +/- 0.02%
     /// between 0 deg C and 50 deg C)
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     pub fn as_vapor_pressure(&self, temp: Temperature) -> Pressure {
         let temp = temp.as_celsius();
         let saturation_vapor_pressure =
@@ -125,7 +125,7 @@ impl Humidity {
     /// Calculates humidity from dewpoint and air temperature using the Magnus-Tetens
     /// Approximation, with coefficients derived by Alduchov and Eskridge (1996). The formulas assume
     //  standard atmospheric pressure.
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn from_dewpoint(dewpoint: Temperature, temp: Temperature) -> Humidity {
         let dewpoint = dewpoint.as_celsius();
         let temp = temp.as_celsius();
@@ -138,7 +138,7 @@ impl Humidity {
     /// Calculates humidity from dewpoint and air temperature using the Magnus-Tetens
     /// Approximation, with coefficients derived by Alduchov and Eskridge (1996). The formulas assume
     //  standard atmospheric pressure.
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     pub fn from_dewpoint(dewpoint: Temperature, temp: Temperature) -> Humidity {
         let dewpoint = dewpoint.as_celsius();
         let temp = temp.as_celsius();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@
 //! by an Area to get a Pressure.
 
 #![deny(warnings, missing_docs)]
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use core as std;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use core::time;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::time;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This PR fixes #23 and fixes #47 by replacing the no_std flag with an additive std flag and disabling default features on serde. 

libm is not an optional dependency anymore because it's functions are required in a no_std context. But as they are only used in said context, it should get optimized away if the std flag is enabled.
I'm happy to change that though if anyone has a better suggestion.

I have chosen not to explicitly enable serdes std flag as it is not required in this library and any consuming application will have that enable anyways if they are using serde in an std context, or am I missing a case there?