### PR TITLE
Allow singular `lb` in `from_str()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Added
 
 - Derive `Default` for all measurement structs
+- make `lb` an option for mass in FromStr implementation (works the same as `lbs` does currently)
 
 ## [0.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Added
 
 - Derive `Default` for all measurement structs
-- make `lb` an option for mass in FromStr implementation (works the same as `lbs` does currently)
+- Accept `lb` as a synonym for `lbs` for mass.
 
 ## [0.11.0]
 

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -280,7 +280,7 @@ impl FromStr for Mass {
                     "dwt" => Mass::from_pennyweights(float_val.parse::<f64>()?),
                     "oz" => Mass::from_ounces(float_val.parse::<f64>()?),
                     "st" => Mass::from_stones(float_val.parse::<f64>()?),
-                    "lbs" => Mass::from_pounds(float_val.parse::<f64>()?),
+                    "lb" | "lbs" => Mass::from_pounds(float_val.parse::<f64>()?),
                     _ => Mass::from_grams(float_val.parse::<f64>()?),
                 },
             );
@@ -602,6 +602,7 @@ mod test {
     fn pounds_from_string() {
         assert_almost_eq(123.0, Mass::from_str("123lbs").unwrap().as_pounds());
         assert_almost_eq(123.0, Mass::from_str("123 lbs").unwrap().as_pounds());
+        assert_almost_eq(123.0, Mass::from_str("123 lb").unwrap().as_pounds());
     }
 
     #[test]


### PR DESCRIPTION
Parsing mass currently breaks on something like `1 lb` which seems like a bit of an oversight, this should fix that