### PR TITLE
Align member implementation order with trait

### DIFF
--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -69,16 +69,16 @@ impl Acceleration {
 }
 
 impl Measurement for Acceleration {
+    fn get_base_units_name(&self) -> &'static str {
+        "m/s\u{00B2}"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.meters_per_second_per_second
     }
 
     fn from_base_units(units: f64) -> Self {
         Self::from_meters_per_second_per_second(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "m/s\u{00B2}"
     }
 }
 

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -90,16 +90,16 @@ impl Angle {
 }
 
 impl Measurement for Angle {
+    fn get_base_units_name(&self) -> &'static str {
+        "rad"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.radians
     }
 
     fn from_base_units(units: f64) -> Self {
         Self::from_radians(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "rad"
     }
 }
 

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -58,16 +58,16 @@ impl AngularVelocity {
 }
 
 impl Measurement for AngularVelocity {
+    fn get_base_units_name(&self) -> &'static str {
+        "rad/s"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.radians_per_second
     }
 
     fn from_base_units(units: f64) -> Self {
         Self::from_radians_per_second(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "rad/s"
     }
 }
 

--- a/src/area.rs
+++ b/src/area.rs
@@ -277,18 +277,6 @@ impl Area {
 }
 
 impl Measurement for Area {
-    fn as_base_units(&self) -> f64 {
-        self.square_meters
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_square_meters(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "m\u{00B2}"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -302,6 +290,18 @@ impl Measurement for Area {
             ("million km\u{00B2}", 1e12),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "m\u{00B2}"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.square_meters
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_square_meters(units)
     }
 }
 

--- a/src/current.rs
+++ b/src/current.rs
@@ -64,18 +64,6 @@ impl Current {
 }
 
 impl Measurement for Current {
-    fn as_base_units(&self) -> f64 {
-        self.amperes
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_amperes(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "A"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to Largest
         let list = [
@@ -93,6 +81,18 @@ impl Measurement for Current {
             ("EA", 1e18),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "A"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.amperes
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_amperes(units)
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -139,18 +139,6 @@ impl Data {
 }
 
 impl Measurement for Data {
-    fn as_base_units(&self) -> f64 {
-        self.octets
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_octets(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "octets"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -163,6 +151,18 @@ impl Measurement for Data {
             ("EiB", 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "octets"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.octets
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_octets(units)
     }
 }
 

--- a/src/density.rs
+++ b/src/density.rs
@@ -110,16 +110,16 @@ impl ::std::ops::Mul<Volume> for Density {
 }
 
 impl Measurement for Density {
+    fn get_base_units_name(&self) -> &'static str {
+        "kg/m\u{00B3}"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.kilograms_per_cubic_meter
     }
 
     fn from_base_units(units: f64) -> Self {
         Self::from_kilograms_per_cubic_meter(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "kg/m\u{00B3}"
     }
 }
 

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -82,18 +82,6 @@ impl Energy {
 }
 
 impl Measurement for Energy {
-    fn as_base_units(&self) -> f64 {
-        self.joules
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_joules(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "J"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to Largest
         let list = [
@@ -111,6 +99,18 @@ impl Measurement for Energy {
             ("EJ", 1e18),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "J"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.joules
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_joules(units)
     }
 }
 

--- a/src/force.rs
+++ b/src/force.rs
@@ -107,18 +107,6 @@ impl Force {
 }
 
 impl Measurement for Force {
-    fn as_base_units(&self) -> f64 {
-        self.newtons
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_newtons(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "N"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -132,6 +120,18 @@ impl Measurement for Force {
             ("TN", 1e12),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "N"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.newtons
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_newtons(units)
     }
 }
 

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -131,18 +131,6 @@ impl Frequency {
 }
 
 impl Measurement for Frequency {
-    fn as_base_units(&self) -> f64 {
-        self.hertz
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_hertz(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "Hz"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -156,6 +144,18 @@ impl Measurement for Frequency {
             ("THz", 1e12),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "Hz"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.hertz
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_hertz(units)
     }
 }
 

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -150,16 +150,16 @@ impl Humidity {
 }
 
 impl Measurement for Humidity {
+    fn get_base_units_name(&self) -> &'static str {
+        "%"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.relative_humidity
     }
 
     fn from_base_units(relative_humidity: f64) -> Self {
         Self::from_percent(relative_humidity)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "%"
     }
 }
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -266,18 +266,6 @@ impl Length {
 }
 
 impl Measurement for Length {
-    fn as_base_units(&self) -> f64 {
-        self.meters
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_meters(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "m"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -292,6 +280,18 @@ impl Measurement for Length {
             ("million km", 1e9),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "m"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.meters
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_meters(units)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,10 @@ macro_rules! impl_maths {
 }
 
 impl Measurement for time::Duration {
+    fn get_base_units_name(&self) -> &'static str {
+        "s"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.as_secs() as f64 + (f64::from(self.subsec_nanos()) * 1e-9)
     }
@@ -168,10 +172,6 @@ impl Measurement for time::Duration {
         let subsec_nanos = ((units * 1e9) % 1e9) as u32;
         let secs = units as u64;
         time::Duration::new(secs, subsec_nanos)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "s"
     }
 }
 

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -226,18 +226,6 @@ impl Mass {
 }
 
 impl Measurement for Mass {
-    fn as_base_units(&self) -> f64 {
-        self.kilograms
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_kilograms(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "kg"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -251,6 +239,18 @@ impl Measurement for Mass {
             ("million tonnes", 1e9),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "kg"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.kilograms
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_kilograms(units)
     }
 }
 

--- a/src/power.rs
+++ b/src/power.rs
@@ -116,18 +116,6 @@ impl Power {
 }
 
 impl Measurement for Power {
-    fn as_base_units(&self) -> f64 {
-        self.watts
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_watts(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "W"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to Largest
         let list = [
@@ -145,6 +133,18 @@ impl Measurement for Power {
             ("EW", 1e18),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "W"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.watts
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_watts(units)
     }
 }
 

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -106,18 +106,6 @@ impl Pressure {
 }
 
 impl Measurement for Pressure {
-    fn as_base_units(&self) -> f64 {
-        self.pascals
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_pascals(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "Pa"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         let list = [
             ("mPa", 1e-3),
@@ -129,6 +117,18 @@ impl Measurement for Pressure {
             ("TPa", 1e12),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "Pa"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.pascals
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_pascals(units)
     }
 }
 

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -54,18 +54,6 @@ impl Resistance {
 }
 
 impl Measurement for Resistance {
-    fn as_base_units(&self) -> f64 {
-        self.ohms
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_ohms(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "\u{2126}"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to Largest
         let list = [
@@ -83,6 +71,18 @@ impl Measurement for Resistance {
             ("E\u{2126}", 1e18),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "\u{2126}"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.ohms
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_ohms(units)
     }
 }
 

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -83,18 +83,6 @@ impl Speed {
 }
 
 impl Measurement for Speed {
-    fn as_base_units(&self) -> f64 {
-        self.meters_per_second
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_meters_per_second(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "m/s"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -107,6 +95,18 @@ impl Measurement for Speed {
             ("million km/s", 1e9),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "m/s"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.meters_per_second
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_meters_per_second(units)
     }
 }
 

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -132,6 +132,10 @@ impl Temperature {
 }
 
 impl Measurement for Temperature {
+    fn get_base_units_name(&self) -> &'static str {
+        "K"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.degrees_kelvin
     }
@@ -139,23 +143,19 @@ impl Measurement for Temperature {
     fn from_base_units(degrees_kelvin: f64) -> Self {
         Self::from_kelvin(degrees_kelvin)
     }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "K"
-    }
 }
 
 impl Measurement for TemperatureDelta {
+    fn get_base_units_name(&self) -> &'static str {
+        "K"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.kelvin_degrees
     }
 
     fn from_base_units(kelvin_degrees: f64) -> Self {
         Self::from_kelvin(kelvin_degrees)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "K"
     }
 }
 

--- a/src/torque.rs
+++ b/src/torque.rs
@@ -54,16 +54,16 @@ impl Torque {
 }
 
 impl Measurement for Torque {
+    fn get_base_units_name(&self) -> &'static str {
+        "Nm"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.newton_metres
     }
 
     fn from_base_units(units: f64) -> Self {
         Self::from_newton_metres(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "Nm"
     }
 }
 

--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -25,6 +25,10 @@ impl std::convert::From<TorqueEnergy> for Energy {
 }
 
 impl Measurement for TorqueEnergy {
+    fn get_base_units_name(&self) -> &'static str {
+        "Nm||J"
+    }
+
     fn as_base_units(&self) -> f64 {
         self.newton_metres
     }
@@ -33,9 +37,5 @@ impl Measurement for TorqueEnergy {
         TorqueEnergy {
             newton_metres: units,
         }
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "Nm||J"
     }
 }

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -64,18 +64,6 @@ impl Voltage {
 }
 
 impl Measurement for Voltage {
-    fn as_base_units(&self) -> f64 {
-        self.volts
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_volts(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "V"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to Largest
         let list = [
@@ -93,6 +81,18 @@ impl Measurement for Voltage {
             ("EV", 1e18),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "V"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.volts
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_volts(units)
     }
 }
 

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -294,18 +294,6 @@ impl Volume {
 }
 
 impl Measurement for Volume {
-    fn as_base_units(&self) -> f64 {
-        self.liters
-    }
-
-    fn from_base_units(units: f64) -> Self {
-        Self::from_liters(units)
-    }
-
-    fn get_base_units_name(&self) -> &'static str {
-        "l"
-    }
-
     fn get_appropriate_units(&self) -> (&'static str, f64) {
         // Smallest to largest
         let list = [
@@ -318,6 +306,18 @@ impl Measurement for Volume {
             ("km\u{00B3}", 1e12),
         ];
         self.pick_appropriate_units(&list)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "l"
+    }
+
+    fn as_base_units(&self) -> f64 {
+        self.liters
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_liters(units)
     }
 }
 


### PR DESCRIPTION
All this PR does is reorder the `impl Measurement` blocks such that the order of function implementations aligns with the declaration order in the `Measurement` trait itself. Nothing else was changed.

This resolves the "Different impl member order from the trait" warnings in JetBrains IDE's Rust plugin.