### PR TITLE
Clean up imports, fix doc lints, get doctests to pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        FEATURES: ['', 'from_str', 'std']
+        FEATURES: ['', 'from_str', 'std', 'serde']
 
         include:
           # Test nightly but don't fail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.1 # clippy is too much of a moving target at the moment
+          toolchain: 1.76 # clippy is too much of a moving target at the moment
           override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["measurements", "lengths", "weights", "temperatures", "volumes"]
 description = "Handle metric, imperial, and other measurements with ease! Types: Length, Temperature, Weight, Volume, Pressure"
 license = "MIT"
 readme = "README.md"
+edition = "2018"
 
 [features]
 std = []

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ measurements = "0.11"
 In your code...
 
 ```rust
-extern crate measurements;
-
 use measurements::{Length, Pressure, Temperature, Volume, Mass};
 
 fn main() {

--- a/examples/engine.rs
+++ b/examples/engine.rs
@@ -1,4 +1,3 @@
-extern crate measurements;
 use measurements::{AngularVelocity, Power};
 
 fn main() {

--- a/examples/format_test.rs
+++ b/examples/format_test.rs
@@ -1,4 +1,3 @@
-extern crate measurements;
 use measurements::*;
 
 fn main() {

--- a/examples/frequency.rs
+++ b/examples/frequency.rs
@@ -1,5 +1,3 @@
-extern crate measurements;
-
 fn main() {
     // Sinusiodal Oscilator moves at 5 Hz across 50 mm
     let f = measurements::Frequency::from_hertz(5.0);

--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -120,6 +120,9 @@ mod test {
 
     use crate::{speed::Speed, test_utils::assert_almost_eq, *};
 
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
+
     // Metric
     #[test]
     fn speed_over_time() {

--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 ///     println!("You accelerated over {} at an average of {}", track, accel);
 ///}
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Acceleration {
     meters_per_second_per_second: f64,

--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -1,7 +1,6 @@
 //! Types and constants for handling acceleration.
 
-use super::length;
-use super::measurement::*;
+use crate::{length, measurement::*};
 #[cfg(feature = "from_str")]
 use regex::Regex;
 #[cfg(feature = "from_str")]
@@ -13,7 +12,6 @@ use std::str::FromStr;
 /// # Example
 ///
 /// ```
-/// extern crate measurements;
 /// use measurements::{Acceleration, Length, Speed};
 /// use std::time::Duration;
 ///
@@ -120,15 +118,13 @@ implement_measurement! { Acceleration }
 #[cfg(test)]
 mod test {
 
-    use super::*;
-    use speed::Speed;
-    use test_utils::assert_almost_eq;
+    use crate::{speed::Speed, test_utils::assert_almost_eq, *};
 
     // Metric
     #[test]
     fn speed_over_time() {
         let s1 = Speed::from_meters_per_second(10.0);
-        let t1 = ::time::Duration::new(5, 0);
+        let t1 = crate::time::Duration::new(5, 0);
         let i1 = s1 / t1;
         let r1 = i1.as_meters_per_second_per_second();
         assert_almost_eq(r1, 2.0);

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -28,7 +28,7 @@ pub struct Angle {
 impl Angle {
     /// Create a new Angle from a floating point value in degrees
     pub fn from_degrees(degrees: f64) -> Self {
-        Angle::from_radians(degrees * ::PI / 180.0)
+        Angle::from_radians(degrees * crate::PI / 180.0)
     }
 
     /// Create a new Angle from a floating point value in radians
@@ -38,7 +38,7 @@ impl Angle {
 
     /// Convert this Angle to a floating point value in degrees
     pub fn as_degrees(&self) -> f64 {
-        self.radians * 180.0 / ::PI
+        self.radians * 180.0 / crate::PI
     }
 
     /// Convert this Angle to a floating point value in radians
@@ -134,9 +134,7 @@ implement_measurement! { Angle }
 
 #[cfg(test)]
 mod test {
-    use angle::*;
-    use std::f64::consts::PI;
-    use test_utils::assert_almost_eq;
+    use crate::{angle::*, test_utils::assert_almost_eq, PI};
 
     #[test]
     fn radians() {

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 /// let slice = whole_cake / pieces;
 /// println!("Each slice will be {} degrees", slice.as_degrees());
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Angle {
     radians: f64,

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -1,11 +1,11 @@
 //! Types and constants for handling speed of rotation (angular velocity)
 
 use super::measurement::*;
+use crate::PI;
 #[cfg(feature = "from_str")]
 use regex::Regex;
 #[cfg(feature = "from_str")]
 use std::str::FromStr;
-use PI;
 
 /// The 'AngularVelocity' struct can be used to deal with angular velocities in a common way.
 ///
@@ -106,7 +106,7 @@ implement_measurement! { AngularVelocity }
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::assert_almost_eq;
+    use crate::test_utils::assert_almost_eq;
 
     #[test]
     fn rpm() {

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 /// let engine_speed = AngularVelocity::from_rpm(9000.0);
 /// let sparks_per_second = (engine_speed.as_hertz() / 2.0) * cylinders;
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct AngularVelocity {
     radians_per_second: f64,

--- a/src/area.rs
+++ b/src/area.rs
@@ -359,8 +359,7 @@ implement_measurement! { Area }
 
 #[cfg(test)]
 mod test {
-    use area::*;
-    use test_utils::assert_almost_eq;
+    use crate::{area::*, test_utils::assert_almost_eq};
 
     #[test]
     fn square_meters() {

--- a/src/area.rs
+++ b/src/area.rs
@@ -22,7 +22,7 @@ const SQUARE_METER_ACRE_FACTOR: f64 = 1.0 / 4046.86;
 /// let acres = football_field.as_acres();
 /// println!("There are {} acres in a football field.", acres);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Area {
     square_meters: f64,
@@ -318,7 +318,7 @@ impl FromStr for Area {
 
         let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([a-z2\u{00B2}\u{00B5} ]{1,5})\s*$").unwrap();
         if let Some(caps) = re.captures(val) {
-            println!("{:?}", caps);
+            println!("{caps:?}");
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(
                 match caps.get(2).unwrap().as_str().trim().to_lowercase().as_str() {

--- a/src/current.rs
+++ b/src/current.rs
@@ -15,7 +15,7 @@ use super::measurement::*;
 /// let u_a = amperes.as_microamperes();
 /// println!("35 mA correspond to {} A or {} µA", a, u_a);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Current {
     amperes: f64,

--- a/src/current.rs
+++ b/src/current.rs
@@ -100,8 +100,7 @@ implement_measurement! { Current }
 
 #[cfg(test)]
 mod test {
-    use current::*;
-    use test_utils::assert_almost_eq;
+    use crate::{current::*, test_utils::assert_almost_eq};
 
     #[test]
     pub fn as_amperes() {

--- a/src/data.rs
+++ b/src/data.rs
@@ -29,7 +29,7 @@ const OCTET_TEBIOCTET_FACTOR: f64 = 1024.0 * 1024.0 * 1024.0 * 1024.0;
 /// let octets = file_size.as_octets();
 /// println!("There are {} octets in that file.", octets);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Data {
     octets: f64,

--- a/src/data.rs
+++ b/src/data.rs
@@ -170,8 +170,7 @@ implement_measurement! { Data }
 
 #[cfg(test)]
 mod test {
-    use data::*;
-    use test_utils::assert_almost_eq;
+    use crate::{data::*, test_utils::assert_almost_eq};
 
     // Metric
     #[test]

--- a/src/density.rs
+++ b/src/density.rs
@@ -35,7 +35,7 @@ pub const LBCF_KGCM_FACTOR: f64 = 0.062427973725314;
 /// let ounces = (density * Volume::from_quarts(1.0)).as_ounces();
 /// println!("Answer is {} ounces per quart", ounces);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Density {
     kilograms_per_cubic_meter: f64,

--- a/src/density.rs
+++ b/src/density.rs
@@ -73,7 +73,7 @@ impl Density {
 }
 
 // mass / volume = density
-impl ::std::ops::Div<Volume> for Mass {
+impl ::core::ops::Div<Volume> for Mass {
     type Output = Density;
 
     fn div(self, other: Volume) -> Density {
@@ -82,7 +82,7 @@ impl ::std::ops::Div<Volume> for Mass {
 }
 
 // mass / density = volume
-impl ::std::ops::Div<Density> for Mass {
+impl ::core::ops::Div<Density> for Mass {
     type Output = Volume;
 
     fn div(self, other: Density) -> Volume {
@@ -91,7 +91,7 @@ impl ::std::ops::Div<Density> for Mass {
 }
 
 // volume * density = mass
-impl ::std::ops::Mul<Density> for Volume {
+impl ::core::ops::Mul<Density> for Volume {
     type Output = Mass;
 
     fn mul(self, other: Density) -> Mass {
@@ -100,7 +100,7 @@ impl ::std::ops::Mul<Density> for Volume {
 }
 
 // density * volume = mass
-impl ::std::ops::Mul<Volume> for Density {
+impl ::core::ops::Mul<Volume> for Density {
     type Output = Mass;
 
     fn mul(self, other: Volume) -> Mass {

--- a/src/density.rs
+++ b/src/density.rs
@@ -1,8 +1,7 @@
 //! Types and constants for handling density.
 
 use super::measurement::*;
-use mass::Mass;
-use volume::Volume;
+use crate::{mass::Mass, volume::Volume};
 
 // Constants, metric
 /// Number of pound per cubic foot in 1 kilograms per cubic meter
@@ -14,33 +13,27 @@ pub const LBCF_KGCM_FACTOR: f64 = 0.062427973725314;
 /// # Example1 - calculating volume from units of mass and density
 ///
 /// ```
-/// extern crate measurements;
 /// use measurements::{Density, Mass, Volume};
 ///
-/// fn main() {
-///    // Q: A 12 stone man hops into a brimming full bath, completely emersing himself.
-///    // How many gallons of water spill on the floor?
-///    // (Assume The human body is roughly about as dense as water - 1 gm/cm³)
-///    //
-///    let body_density: Density = Mass::from_grams(1.0) / Volume:: from_cubic_centimetres(1.0);
-///    let mans_weight = Mass::from_stones(12.0);
-///    let water_volume = mans_weight / body_density;
-///    println!("{} gallons of water spilled on the floor", water_volume.as_gallons());
-/// }
+/// // Q: A 12 stone man hops into a brimming full bath, completely emersing himself.
+/// // How many gallons of water spill on the floor?
+/// // (Assume The human body is roughly about as dense as water - 1 gm/cm³)
+/// //
+/// let body_density: Density = Mass::from_grams(1.0) / Volume:: from_cubic_centimetres(1.0);
+/// let mans_weight = Mass::from_stones(12.0);
+/// let water_volume = mans_weight / body_density;
+/// println!("{} gallons of water spilled on the floor", water_volume.as_gallons());
 /// ```
 /// # Example2 - converting to ad-hoc units of density
 ///
 /// ```
-/// extern crate measurements;
 /// use measurements::{Density, Mass, Volume};
 ///
-/// fn main() {
-///    // Q: what is 3 grams per litre in units of ounces per quart?
-///    //
-///    let density: Density = Mass::from_grams(3.0) / Volume:: from_litres(1.0);
-///    let ounces = (density * Volume::from_quarts(1.0)).as_ounces();
-///    println!("Answer is {} ounces per quart", ounces);
-/// }
+/// // Q: what is 3 grams per litre in units of ounces per quart?
+/// //
+/// let density: Density = Mass::from_grams(3.0) / Volume:: from_litres(1.0);
+/// let ounces = (density * Volume::from_quarts(1.0)).as_ounces();
+/// println!("Answer is {} ounces per quart", ounces);
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
@@ -128,7 +121,7 @@ implement_measurement! { Density }
 mod test {
 
     use super::*;
-    use test_utils::assert_almost_eq;
+    use crate::test_utils::assert_almost_eq;
 
     // Metric
     #[test]

--- a/src/density.rs
+++ b/src/density.rs
@@ -26,7 +26,7 @@ pub const LBCF_KGCM_FACTOR: f64 = 0.062427973725314;
 ///    let mans_weight = Mass::from_stones(12.0);
 ///    let water_volume = mans_weight / body_density;
 ///    println!("{} gallons of water spilled on the floor", water_volume.as_gallons());
-///}
+/// }
 /// ```
 /// # Example2 - converting to ad-hoc units of density
 ///
@@ -40,9 +40,8 @@ pub const LBCF_KGCM_FACTOR: f64 = 0.062427973725314;
 ///    let density: Density = Mass::from_grams(3.0) / Volume:: from_litres(1.0);
 ///    let ounces = (density * Volume::from_quarts(1.0)).as_ounces();
 ///    println!("Answer is {} ounces per quart", ounces);
-///}
+/// }
 /// ```
-
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Density {

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -118,8 +118,7 @@ implement_measurement! { Energy }
 
 #[cfg(test)]
 mod test {
-    use energy::*;
-    use test_utils::assert_almost_eq;
+    use crate::{energy::*, test_utils::assert_almost_eq};
 
     #[test]
     pub fn as_kcalories() {

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -13,7 +13,7 @@ use super::measurement::*;
 /// let energy = Energy::from_kcalories(2500.0);
 /// println!("Some say a health adult male should consume {} per day", energy);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Energy {
     joules: f64,

--- a/src/force.rs
+++ b/src/force.rs
@@ -139,8 +139,7 @@ implement_measurement! { Force }
 
 #[cfg(test)]
 mod test {
-    use force::*;
-    use test_utils::assert_almost_eq;
+    use crate::{force::*, test_utils::assert_almost_eq};
 
     #[test]
     pub fn newtons() {

--- a/src/force.rs
+++ b/src/force.rs
@@ -28,7 +28,7 @@ pub const DYNES_PER_NEWTON: f64 = 1e5;
 ///     "One metric ton exerts a force of {} due to gravity",
 ///     force);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Force {
     newtons: f64,

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -29,7 +29,7 @@ pub const HERTZ_TERAHERTZ_FACTOR: f64 = 1e-12;
 /// let radio_station = Frequency::from_hertz(101.5e6);
 /// println!("Tune to {}.", radio_station);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Frequency {
     hertz: f64,

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -1,7 +1,7 @@
 //! Types and constants for handling frequencies.
 
 use super::measurement::*;
-use time;
+use crate::time;
 
 /// Number of nanohertz in a Hz
 pub const HERTZ_NANOHERTZ_FACTOR: f64 = 1e9;
@@ -164,8 +164,7 @@ implement_measurement! { Frequency }
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::assert_almost_eq;
-    use time;
+    use crate::{test_utils::assert_almost_eq, time};
 
     #[test]
     pub fn hertz() {

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -163,15 +163,15 @@ impl Measurement for Humidity {
     }
 }
 
-impl ::std::cmp::Eq for Humidity {}
-impl ::std::cmp::PartialEq for Humidity {
+impl ::core::cmp::Eq for Humidity {}
+impl ::core::cmp::PartialEq for Humidity {
     fn eq(&self, other: &Self) -> bool {
         self.as_base_units() == other.as_base_units()
     }
 }
 
-impl ::std::cmp::PartialOrd for Humidity {
-    fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+impl ::core::cmp::PartialOrd for Humidity {
+    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
         self.as_base_units().partial_cmp(&other.as_base_units())
     }
 }

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -1,9 +1,7 @@
 //! Types and constants for handling humidity.
 
 use super::measurement::*;
-use density::Density;
-use pressure::Pressure;
-use temperature::Temperature;
+use crate::{density::Density, pressure::Pressure, temperature::Temperature};
 
 /// The `Humidity` struct can be used to deal with relative humidity
 /// in air in a common way. Relative humidity is an important metric used
@@ -180,8 +178,7 @@ implement_display!(Humidity);
 
 #[cfg(test)]
 mod test {
-    use humidity::*;
-    use test_utils::assert_almost_eq;
+    use crate::{humidity::*, test_utils::assert_almost_eq};
 
     // Humidity Units
     #[test]

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -34,7 +34,7 @@ use crate::{density::Density, pressure::Pressure, temperature::Temperature};
 ///     println!("At {} humidity, air at {} has a dewpoint of {}", humidity, temp, dewpoint);
 ///
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Humidity {
     relative_humidity: f64, // expressed as a percentage

--- a/src/length.rs
+++ b/src/length.rs
@@ -44,7 +44,7 @@ pub const METER_MILE_FACTOR: f64 = 10000.0 / (254.0 * 12.0 * 3.0 * 1760.0);
 /// let meters = football_field.as_meters();
 /// println!("There are {} meters in a football field.", meters);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Length {
     meters: f64,

--- a/src/length.rs
+++ b/src/length.rs
@@ -299,8 +299,7 @@ implement_measurement! { Length }
 
 #[cfg(test)]
 mod test {
-    use length::*;
-    use test_utils::assert_almost_eq;
+    use crate::{length::*, test_utils::assert_almost_eq};
 
     // Metric
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,21 +10,18 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
-use core as std;
-#[cfg(not(feature = "std"))]
 use core::time;
 
 #[cfg(feature = "std")]
 use std::time;
 
 #[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
+use serde;
 
 #[cfg(feature = "from_str")]
-extern crate regex;
+use regex;
 
-use std::f64::consts::PI;
+use core::f64::consts::PI;
 
 #[macro_use]
 mod measurement;
@@ -107,7 +104,7 @@ pub mod test_utils;
 ///     - C = A / B
 macro_rules! impl_maths {
     ($a:ty, $b:ty) => {
-        impl std::ops::Mul<$b> for $b {
+        impl core::ops::Mul<$b> for $b {
             type Output = $a;
 
             fn mul(self, rhs: $b) -> Self::Output {
@@ -115,7 +112,7 @@ macro_rules! impl_maths {
             }
         }
 
-        impl std::ops::Div<$b> for $a {
+        impl core::ops::Div<$b> for $a {
             type Output = $b;
 
             fn div(self, rhs: $b) -> Self::Output {
@@ -125,7 +122,7 @@ macro_rules! impl_maths {
     };
 
     ($a:ty, $b:ty, $c:ty) => {
-        impl std::ops::Mul<$b> for $c {
+        impl core::ops::Mul<$b> for $c {
             type Output = $a;
 
             fn mul(self, rhs: $b) -> Self::Output {
@@ -133,7 +130,7 @@ macro_rules! impl_maths {
             }
         }
 
-        impl std::ops::Mul<$c> for $b {
+        impl core::ops::Mul<$c> for $b {
             type Output = $a;
 
             fn mul(self, rhs: $c) -> Self::Output {
@@ -141,7 +138,7 @@ macro_rules! impl_maths {
             }
         }
 
-        impl std::ops::Div<$c> for $a {
+        impl core::ops::Div<$c> for $a {
             type Output = $b;
 
             fn div(self, rhs: $c) -> Self::Output {
@@ -149,7 +146,7 @@ macro_rules! impl_maths {
             }
         }
 
-        impl std::ops::Div<$b> for $a {
+        impl core::ops::Div<$b> for $a {
             type Output = $c;
 
             fn div(self, rhs: $b) -> Self::Output {
@@ -195,7 +192,7 @@ impl_maths!(TorqueEnergy, Force, Length);
 // Implement the divisions manually (the above macro only implemented the
 // TorqueEnergy / X operations).
 
-impl std::ops::Div<Length> for Torque {
+impl core::ops::Div<Length> for Torque {
     type Output = Force;
 
     fn div(self, rhs: Length) -> Self::Output {
@@ -203,7 +200,7 @@ impl std::ops::Div<Length> for Torque {
     }
 }
 
-impl std::ops::Div<Force> for Torque {
+impl core::ops::Div<Force> for Torque {
     type Output = Length;
 
     fn div(self, rhs: Force) -> Self::Output {
@@ -211,7 +208,7 @@ impl std::ops::Div<Force> for Torque {
     }
 }
 
-impl std::ops::Div<Length> for Energy {
+impl core::ops::Div<Length> for Energy {
     type Output = Force;
 
     fn div(self, rhs: Length) -> Self::Output {
@@ -219,7 +216,7 @@ impl std::ops::Div<Length> for Energy {
     }
 }
 
-impl std::ops::Div<Force> for Energy {
+impl core::ops::Div<Force> for Energy {
     type Output = Length;
 
     fn div(self, rhs: Force) -> Self::Output {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@ use core::time;
 #[cfg(feature = "std")]
 use std::time;
 
-#[cfg(feature = "serde")]
-use serde;
-
 use core::f64::consts::PI;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,6 @@ use std::time;
 #[cfg(feature = "serde")]
 use serde;
 
-#[cfg(feature = "from_str")]
-use regex;
-
 use core::f64::consts::PI;
 
 #[macro_use]

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -57,7 +57,7 @@ pub const KILOGRAM_LONG_TONS_FACTOR: f64 = KILOGRAM_POUNDS_FACTOR / 2240.0;
 ///     "One metric ton is {} U.S. tons - that's {} pounds!",
 ///     united_states_tons, united_states_pounds);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Mass {
     kilograms: f64,

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -294,8 +294,7 @@ implement_measurement! { Mass }
 
 #[cfg(test)]
 mod test {
-    use mass::*;
-    use test_utils::assert_almost_eq;
+    use crate::{mass::*, test_utils::assert_almost_eq};
 
     // Mass Units
     // Metric

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -7,12 +7,8 @@
 ///
 /// # Example
 /// ```
-/// extern crate core;
-/// // Importing the `implement_measurement` macro from the external crate is important
-/// #[macro_use]
-/// extern crate measurements;
-///
-/// use measurements::Measurement;
+/// // Importing the `implement_display` and `implement_measurement` macros from the `measurements` crate
+/// use measurements::{implement_display, implement_measurement, Measurement};
 ///
 ///
 /// struct Cubits {

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -1,9 +1,12 @@
-/// The `Measurement` trait and the `implement_measurement!` macro
-/// provides a common way for various measurements to be implemented.
+//! The `Measurement` trait and the `implement_measurement!` macro
+//! provides a common way for various measurements to be implemented.
+///
+/// All measurements implement this.
+///
+/// It provides conversion functions to and from raw numbers.
 ///
 /// # Example
 /// ```
-/// #![no_std]
 /// // Importing the `implement_measurement` macro from the external crate is important
 /// #[macro_use]
 /// extern crate measurements;
@@ -35,16 +38,9 @@
 /// // You should't need it in your own code.
 /// fn main() { }
 /// ```
-
-#[cfg(feature = "no-std")]
-use core as std;
-
-#[cfg(feature = "no-std")]
-use core::num::Float;
-
-/// All measurements implement this.
 ///
-/// It provides conversion functions to and from raw numbers.
+/// *Note*: If you are in a `no_std` environment, you have to
+/// `use core as std;` for the macros to run.
 pub trait Measurement {
     /// Returns a string containing the most appropriate units for this quantity,
     /// and a floating point value representing this quantity in those units.

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -7,11 +7,13 @@
 ///
 /// # Example
 /// ```
+/// extern crate core;
 /// // Importing the `implement_measurement` macro from the external crate is important
 /// #[macro_use]
 /// extern crate measurements;
 ///
 /// use measurements::Measurement;
+///
 ///
 /// struct Cubits {
 ///     forearms: f64
@@ -38,9 +40,6 @@
 /// // You should't need it in your own code.
 /// fn main() { }
 /// ```
-///
-/// *Note*: If you are in a `no_std` environment, you have to
-/// `use core as std;` for the macros to run.
 pub trait Measurement {
     /// Returns a string containing the most appropriate units for this quantity,
     /// and a floating point value representing this quantity in those units.
@@ -80,13 +79,13 @@ pub trait Measurement {
 }
 
 /// This is a special macro that creates the code to implement
-/// `std::fmt::Display`.
+/// `core::fmt::Display`.
 #[macro_export]
 macro_rules! implement_display {
     ($($t:ty)*) => ($(
 
-        impl ::std::fmt::Display for $t {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Display for $t {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 let (unit, value) = self.get_appropriate_units();
                 value.fmt(f)?;      // Value
                 write!(f, "\u{00A0}{}", unit)
@@ -103,7 +102,7 @@ macro_rules! implement_measurement {
 
         implement_display!( $t );
 
-        impl ::std::ops::Add for $t {
+        impl ::core::ops::Add for $t {
             type Output = Self;
 
             fn add(self, rhs: Self) -> Self {
@@ -111,7 +110,7 @@ macro_rules! implement_measurement {
             }
         }
 
-        impl ::std::ops::Sub for $t {
+        impl ::core::ops::Sub for $t {
             type Output = Self;
 
             fn sub(self, rhs: Self) -> Self {
@@ -121,7 +120,7 @@ macro_rules! implement_measurement {
 
         // Dividing a `$t` by another `$t` returns a ratio.
         //
-        impl ::std::ops::Div<$t> for $t {
+        impl ::core::ops::Div<$t> for $t {
             type Output = f64;
 
             fn div(self, rhs: Self) -> f64 {
@@ -131,7 +130,7 @@ macro_rules! implement_measurement {
 
         // Dividing a `$t` by a factor returns a new portion of the measurement.
         //
-        impl ::std::ops::Div<f64> for $t {
+        impl ::core::ops::Div<f64> for $t {
             type Output = Self;
 
             fn div(self, rhs: f64) -> Self {
@@ -141,7 +140,7 @@ macro_rules! implement_measurement {
 
         // Multiplying a `$t` by a factor increases (or decreases) that
         // measurement a number of times.
-        impl ::std::ops::Mul<f64> for $t {
+        impl ::core::ops::Mul<f64> for $t {
             type Output = Self;
 
             fn mul(self, rhs: f64) -> Self {
@@ -150,7 +149,7 @@ macro_rules! implement_measurement {
         }
 
         // Multiplying `$t` by a factor is commutative
-        impl ::std::ops::Mul<$t> for f64 {
+        impl ::core::ops::Mul<$t> for f64 {
             type Output = $t;
 
             fn mul(self, rhs: $t) -> $t {
@@ -158,15 +157,15 @@ macro_rules! implement_measurement {
             }
         }
 
-        impl ::std::cmp::Eq for $t { }
-        impl ::std::cmp::PartialEq for $t {
+        impl ::core::cmp::Eq for $t { }
+        impl ::core::cmp::PartialEq for $t {
             fn eq(&self, other: &Self) -> bool {
                 self.as_base_units() == other.as_base_units()
             }
         }
 
-        impl ::std::cmp::PartialOrd for $t {
-            fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+        impl ::core::cmp::PartialOrd for $t {
+            fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
                 self.as_base_units().partial_cmp(&other.as_base_units())
             }
         }

--- a/src/power.rs
+++ b/src/power.rs
@@ -27,7 +27,7 @@ pub const WATT_PS_FACTOR: f64 = 1.0 / 735.499;
 /// let k_w = power.as_kilowatts();
 /// println!("A 100.0 hp car produces {} kW", k_w);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Power {
     watts: f64,

--- a/src/power.rs
+++ b/src/power.rs
@@ -152,10 +152,7 @@ implement_measurement! { Power }
 
 #[cfg(test)]
 mod test {
-    use current::*;
-    use power::*;
-    use test_utils::assert_almost_eq;
-    use voltage::*;
+    use crate::{current::*, power::*, test_utils::assert_almost_eq, voltage::*};
 
     #[test]
     pub fn as_btu_per_minute() {

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -27,7 +27,7 @@ pub const PASCAL_PSI_FACTOR: f64 = 6894.76;
 /// let mbar = earth.as_millibars();
 /// println!("Atmospheric pressure is {} mbar.", mbar);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Pressure {
     pascals: f64,

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -137,7 +137,7 @@ implement_measurement! { Pressure }
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::assert_almost_eq;
+    use crate::test_utils::assert_almost_eq;
 
     #[test]
     fn hectopascals() {

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -15,7 +15,7 @@ use super::measurement::*;
 /// let mo = r.as_megaohms();
 /// println!("A 4.7 kΩ resistor has {} Ω or {} MΩ", o, mo);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Resistance {
     ohms: f64,

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -90,8 +90,7 @@ implement_measurement! { Resistance }
 
 #[cfg(test)]
 mod test {
-    use resistance::*;
-    use test_utils::assert_almost_eq;
+    use crate::{resistance::*, test_utils::assert_almost_eq};
 
     #[test]
     pub fn as_ohms() {

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -22,7 +22,7 @@ pub const SECONDS_HOURS_FACTOR: f64 = 60.0 * 60.0;
 /// let mph = light.as_miles_per_hour();
 /// println!("The speed of light is {} mph.", mph);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Speed {
     meters_per_second: f64,

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -114,10 +114,7 @@ implement_measurement! { Speed }
 
 #[cfg(test)]
 mod test {
-    use length::Length;
-    use speed::*;
-    use test_utils::assert_almost_eq;
-    use time::Duration;
+    use crate::{length::Length, speed::*, test_utils::assert_almost_eq, time::Duration};
 
     // Metric
     #[test]

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -159,7 +159,7 @@ impl Measurement for TemperatureDelta {
     }
 }
 
-impl ::std::ops::Add<TemperatureDelta> for Temperature {
+impl ::core::ops::Add<TemperatureDelta> for Temperature {
     type Output = Temperature;
 
     fn add(self, other: TemperatureDelta) -> Temperature {
@@ -167,7 +167,7 @@ impl ::std::ops::Add<TemperatureDelta> for Temperature {
     }
 }
 
-impl ::std::ops::Add<Temperature> for TemperatureDelta {
+impl ::core::ops::Add<Temperature> for TemperatureDelta {
     type Output = Temperature;
 
     fn add(self, other: Temperature) -> Temperature {
@@ -175,7 +175,7 @@ impl ::std::ops::Add<Temperature> for TemperatureDelta {
     }
 }
 
-impl ::std::ops::Sub<TemperatureDelta> for Temperature {
+impl ::core::ops::Sub<TemperatureDelta> for Temperature {
     type Output = Temperature;
 
     fn sub(self, other: TemperatureDelta) -> Temperature {
@@ -183,7 +183,7 @@ impl ::std::ops::Sub<TemperatureDelta> for Temperature {
     }
 }
 
-impl ::std::ops::Sub<Temperature> for Temperature {
+impl ::core::ops::Sub<Temperature> for Temperature {
     type Output = TemperatureDelta;
 
     fn sub(self, other: Temperature) -> TemperatureDelta {
@@ -191,15 +191,15 @@ impl ::std::ops::Sub<Temperature> for Temperature {
     }
 }
 
-impl ::std::cmp::Eq for Temperature {}
-impl ::std::cmp::PartialEq for Temperature {
+impl ::core::cmp::Eq for Temperature {}
+impl ::core::cmp::PartialEq for Temperature {
     fn eq(&self, other: &Self) -> bool {
         self.as_base_units() == other.as_base_units()
     }
 }
 
-impl ::std::cmp::PartialOrd for Temperature {
-    fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+impl ::core::cmp::PartialOrd for Temperature {
+    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
         self.as_base_units().partial_cmp(&other.as_base_units())
     }
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -238,8 +238,7 @@ implement_measurement!(TemperatureDelta);
 
 #[cfg(test)]
 mod test {
-    use temperature::*;
-    use test_utils::assert_almost_eq;
+    use crate::{temperature::*, test_utils::assert_almost_eq};
 
     // Temperature Units
     #[test]

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 /// let fahrenheit = boiling_water.as_fahrenheit();
 /// println!("Boiling water measures at {} degrees fahrenheit.", fahrenheit);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Temperature {
     degrees_kelvin: f64,
@@ -37,7 +37,7 @@ pub struct Temperature {
 /// let difference: TemperatureDelta = boiling_water - frozen_water;
 /// println!("Boiling water is {} above freezing.", difference);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct TemperatureDelta {
     kelvin_degrees: f64,

--- a/src/torque.rs
+++ b/src/torque.rs
@@ -72,7 +72,7 @@ implement_measurement! { Torque }
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::assert_almost_eq;
+    use crate::test_utils::assert_almost_eq;
 
     #[test]
     fn lbf_ft() {

--- a/src/torque.rs
+++ b/src/torque.rs
@@ -15,7 +15,7 @@ const NEWTON_METRE_POUND_FOOT_FACTOR: f64 = 0.73756326522588;
 /// let engine_torque = Torque::from_pound_foot(250.0);
 /// println!("In metric, that's {} Nm", engine_torque.as_newton_metres());
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Torque {
     newton_metres: f64,

--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -12,13 +12,13 @@ pub struct TorqueEnergy {
     newton_metres: f64,
 }
 
-impl std::convert::From<TorqueEnergy> for Torque {
+impl core::convert::From<TorqueEnergy> for Torque {
     fn from(t: TorqueEnergy) -> Torque {
         Torque::from_newton_metres(t.newton_metres)
     }
 }
 
-impl std::convert::From<TorqueEnergy> for Energy {
+impl core::convert::From<TorqueEnergy> for Energy {
     fn from(t: TorqueEnergy) -> Energy {
         Energy::from_joules(t.newton_metres)
     }

--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -7,7 +7,7 @@ use super::*;
 /// something (which creates a Torque). This struct is what results
 /// from the multiplication, and you have to then convert
 /// it to whichever you want.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TorqueEnergy {
     newton_metres: f64,
 }

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -15,7 +15,7 @@ use super::measurement::*;
 /// let k_v = volts.as_kilovolts();
 /// println!("A 1.5 V battery has {} mV or {} kV", m_v, k_v);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Voltage {
     volts: f64,

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -100,10 +100,7 @@ implement_measurement! { Voltage }
 
 #[cfg(test)]
 mod test {
-    use current::*;
-    use resistance::*;
-    use test_utils::assert_almost_eq;
-    use voltage::*;
+    use crate::{current::*, resistance::*, test_utils::assert_almost_eq, voltage::*};
 
     #[test]
     pub fn as_kilovolts() {

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 /// let beers = gallon / pint;
 /// println!("A gallon of beer will pour {} pints!", beers);
 /// ```
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Volume {
     liters: f64,

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -372,8 +372,7 @@ implement_measurement! { Volume }
 
 #[cfg(test)]
 mod test {
-    use test_utils::assert_almost_eq;
-    use volume::*;
+    use crate::{test_utils::assert_almost_eq, volume::*};
 
     // Volume Units
     // Metric

--- a/tests/frequency.rs
+++ b/tests/frequency.rs
@@ -1,5 +1,3 @@
-extern crate measurements;
-
 use measurements::test_utils::assert_almost_eq;
 
 #[test]

--- a/tests/get_appropriate_units.rs
+++ b/tests/get_appropriate_units.rs
@@ -1,5 +1,3 @@
-extern crate measurements;
-
 use measurements::{mass::Mass, test_utils::assert_almost_eq, Measurement};
 
 // Macro for testing `get_appropriate_units()`.

--- a/tests/pressure.rs
+++ b/tests/pressure.rs
@@ -1,4 +1,3 @@
-extern crate measurements;
 use measurements::prelude::*;
 
 #[test]

--- a/tests/torque_and_energy.rs
+++ b/tests/torque_and_energy.rs
@@ -1,5 +1,3 @@
-extern crate measurements;
-
 use measurements::*;
 
 #[test]


### PR DESCRIPTION
As discussed in #58, this cleans up the following:

- Remove the unused imports that are behind feature gates that don't exist anymore
- Clean up lints for documentation

This cleanup also made the example in `measurements.rs` discoverable as a doc test, and it didn't pass due to the `![no_std]` configuration. Removed the `![no_std]` configuration in the example, reordered the description such that the example now also shows up in the docs, and added a note that in `no_std` environments, `use core as std` is required when using the macros.