### PR TITLE
Modernize CI to use current, non-archived actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        FEATURES: ['', 'from_str', 'std', 'serde']
+        FEATURES: ['', 'from_str', 'std', 'serde', 'regex']
         TARGET: ['x86_64-unknown-linux-gnu']
 
         include:
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        FEATURES: ['', 'from_str', 'std', 'serde']
+        FEATURES: ['', 'from_str', 'std', 'serde', 'regex']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,15 @@ name: Build
 
 env:
   RUSTFLAGS: '--deny warnings'
+  MSRV: 1.76
 
 jobs:
   build-std:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
         FEATURES: ['', 'from_str', 'std', 'serde']
+        TARGET: ['x86_64-unknown-linux-gnu']
 
         include:
           # Test nightly but don't fail
@@ -22,27 +23,20 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ env.MSRV }}
           target: ${{ matrix.TARGET }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=x86_64-unknown-linux-gnu --features=${{ matrix.FEATURES }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=x86_64-unknown-linux-gnu --features=${{ matrix.FEATURES }}
+      - name: Build std
+        run: cargo build --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
+      - name: Test std
+        run: cargo test --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
 
   build-no-std:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
         TARGET: [thumbv6m-none-eabi, thumbv7m-none-eabi]
 
         include:
@@ -52,47 +46,37 @@ jobs:
             TARGET: x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ env.MSRV }}
           target: ${{ matrix.TARGET }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.TARGET }}
+      - name: Build std
+        run: cargo build --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
 
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          toolchain: ${{ env.MSRV }}
+          target: ${{ matrix.TARGET }}
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Format
+        run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        FEATURES: ['', 'from_str', 'std']
+        FEATURES: ['', 'from_str', 'std', 'serde']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: 1.76 # clippy is too much of a moving target at the moment
-          override: true
+          toolchain: ${{ env.MSRV }}
+          target: ${{ matrix.TARGET }}
           components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features=${{ matrix.FEATURES }}
+      - name: Clippy
+        run: cargo clippy --features=${{ matrix.FEATURES }} -- -D warnings


### PR DESCRIPTION
As discussed in #59, this PR updates the CI, which is now using to the following:
- Use `actions/checkout@v4`
- For rust toolchain use `dtonlay/rust-toolchain@stable`

The rust version is pinned with an env variable named `MSRV` to `1.76`. This applies for all builds, tests, fmt, and clippy.

On target `x86_64-unknown-linux-gnu`, all features are built and tested. I also added a matrix entry for the `regex` feature alone, as this has previously only been tested as part of the `from_str` feature. Adding `regex` alone as well seems more consistent, as we also test `std` alone (even though it is part of `from_str` as well). Also continuing to test nightly but don't fail.

On targets `thumbv6m-none-eabi` and `thumbv7m-none-eabi`, as previously, the `cargo build` is run. Continue to do the same with nightly but don't fail.

`cargo fmt` is still here as before, so is `cargo clippy`. The latter again is also matrixed with all features as for the `x86_64...` target.